### PR TITLE
Fix small white bar showing in the corner

### DIFF
--- a/src/Dashboard.css
+++ b/src/Dashboard.css
@@ -5,7 +5,7 @@
   height: 100%;
   padding: 0 172.5px;
   background-image: primaryBackgroundImage;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .Dashboard .Logout {

--- a/src/SessionSummary.css
+++ b/src/SessionSummary.css
@@ -5,7 +5,7 @@
   height: 100%;
   padding: 0 172.5px;
   background-image: primaryBackgroundImage;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .SessionSummary .title-wrapper {


### PR DESCRIPTION
# Issue
- White bar was being showed in the right corner of the page even when there was no scroll to be performed. 

# Fix
- Change a css rule from `overflow-y: scroll` to `overflow-y: auto`