### PR TITLE
Fix docs issues3

### DIFF
--- a/public/icons.svg
+++ b/public/icons.svg
@@ -250,4 +250,18 @@
             </path>
         </g>
     </symbol>
+    <symbol id="fast-backward" viewBox="0 0 512 512">
+        <!--Font-awesome fast-backward https://fontawesome.com/license CC-BY-Attribution !-->
+        <g id="fast-backward">
+            <path fill="currentColor" d="M0 436V76c0-6.6 5.4-12 12-12h40c6.6 0 12 5.4 12 12v151.9L235.5 71.4C256.1 54.3 288 68.6 288 96v131.9L459.5 71.4C480.1 54.3 512 68.6 512 96v320c0 27.4-31.9 41.7-52.5 24.6L288 285.3V416c0 27.4-31.9 41.7-52.5 24.6L64 285.3V436c0 6.6-5.4 12-12 12H12c-6.6 0-12-5.4-12-12z">
+            </path>
+        </g>
+    </symbol>
+    <symbol id="check-solid" viewBox="0 0 512 512">
+        <!--Font-awesome check-solid https://fontawesome.com/license CC-BY-Attribution !-->
+        <g id="check-solid">
+            <path fill="currentColor" d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"/>
+        </g>
+    </symbol>
+    
 </svg>

--- a/src/labelling/labelling.css
+++ b/src/labelling/labelling.css
@@ -50,8 +50,26 @@
   display: inline-block;
 }
 
+.labellingComponent .checkIconWrapper {
+  display: inline-block;
+  background-color: #79f9fe;
+  border-radius: 46px;
+  width: 46px;
+  height: 46px;
+  margin-right: 10px;
+  vertical-align: bottom;
+}
+
+.labellingComponent .checkIcon {
+  width: 20px;
+  height: 20px;
+  margin: 13px;
+  fill: black;
+}
+
 .labellingComponent .commonButtons {
   text-align: center;
+  margin-left: 46px;
 }
 
 .labelling-appear {
@@ -63,7 +81,6 @@
   transition: opacity 500ms linear;
 }
 
-/* exit */
 .labelling-exit {
   opacity: 1;
 }

--- a/src/select-tree/SelectTree.css
+++ b/src/select-tree/SelectTree.css
@@ -49,8 +49,15 @@
 }
 
 .select-tree-root .breadcrumb .backIcon {
-  padding-right: 5px;
-  color: #0000ff;
+  padding-right: 10px;
+}
+
+.select-tree-root .breadcrumb .backIcon svg {
+  width: 14px;
+  height: 14px;
+  position: relative;
+  top: 2px;
+  color: #457fb0;
 }
 
 .select-tree-root .tree-options {

--- a/src/select-tree/SelectTreeBreadcrumb.js
+++ b/src/select-tree/SelectTreeBreadcrumb.js
@@ -18,7 +18,12 @@ class SelectTreeBreadcrumb extends Component {
             onChange={this.props.onSelected}
           />
           <span className="wrapperText">
-            <span className="backIcon">&#x2B05;</span> {this.props.label}
+            <span className="backIcon">
+              <svg>
+                <use xlinkHref="/icons.svg#fast-backward" />
+              </svg>
+            </span>
+            {this.props.label}
           </span>
         </label>
       </div>


### PR DESCRIPTION
# Changes
- Fix back arrow (fastforward arrow from font-awesome) on select-tree
- Fix labelling modal position: set it always to be with top attribute so it wont move down in case the modal is too short. 
- Fix labelling modal react loop: Prevent multiple setState() on componentDidMount