### PR TITLE
fix(contextMenu): Fix menu getting out of page bounds

### DIFF
--- a/src/viewer/ToolContextMenu.css
+++ b/src/viewer/ToolContextMenu.css
@@ -8,6 +8,7 @@
   border-radius: 5px;
   z-index: 1000;
   display: block;
+  width: 160px;
 }
 
 .ToolContextMenu > ul {

--- a/src/viewer/ToolContextMenu.js
+++ b/src/viewer/ToolContextMenu.js
@@ -165,6 +165,12 @@ function getDropdownItems(eventData, isTouchEvent = false) {
 }
 
 class ToolContextMenu extends Component {
+  constructor(props) {
+    super(props);
+
+    this.mainElement = React.createRef();
+  }
+
   render() {
     if (!this.props.toolContextMenuData) {
       return '';
@@ -199,13 +205,54 @@ class ToolContextMenu extends Component {
     };
 
     return (
-      <div className="ToolContextMenu dropdown" style={position}>
+      <div
+        className="ToolContextMenu dropdown"
+        style={position}
+        ref={this.mainElement}
+      >
         <ul className="dropdown-menu dropdown-menu-left bounded">
           {dropdownComponents}
         </ul>
       </div>
     );
   }
+
+  componentDidMount = () => {
+    if (this.mainElement.current) {
+      this.updateElementPosition();
+    }
+  };
+
+  componentDidUpdate = () => {
+    if (this.mainElement.current) {
+      this.updateElementPosition();
+    }
+  };
+
+  updateElementPosition = () => {
+    const {
+      offsetParent,
+      offsetTop,
+      offsetHeight,
+      offsetWidth,
+      offsetLeft
+    } = this.mainElement.current;
+    const { eventData } = this.props.toolContextMenuData;
+    if (offsetTop + offsetHeight > offsetParent.offsetHeight) {
+      const offBoundPixels =
+        offsetTop + offsetHeight - offsetParent.offsetHeight;
+      const top = eventData.currentPoints.canvas.y - offBoundPixels;
+
+      this.mainElement.current.style.top = `${top > 0 ? top : 0}px`;
+    }
+    if (offsetLeft + offsetWidth > offsetParent.offsetWidth) {
+      const offBoundPixels =
+        offsetLeft + offsetWidth - offsetParent.offsetWidth;
+      const left = eventData.currentPoints.canvas.x - offBoundPixels;
+
+      this.mainElement.current.style.left = `${left > 0 ? left : 0}px`;
+    }
+  };
 }
 
 ToolContextMenu.propTypes = {


### PR DESCRIPTION
# Changes
- Added a re-positioning feature once the component is mounted and updated so I cam position it again inside the viewport in case it gets off. 