### PR TITLE
fix(caseFeedback): Close modal on wheel/touch/mouse

### DIFF
--- a/src/viewer/CaseFeedback.js
+++ b/src/viewer/CaseFeedback.js
@@ -101,7 +101,9 @@ class CaseFeedback extends Component {
           <>
             <div
               className="caseFeedbackOptionsBackground"
-              onClick={this.openDropdown}
+              onMouseDown={this.openDropdown}
+              onWheel={this.openDropdown}
+              onTouchStart={this.openDropdown}
             />
             <div
               className={


### PR DESCRIPTION
# Changes
- Close modal with wheel and touch and mouse down instead of click.