### PR TITLE
feat(viewer): Move loading under ViewportOverlay

### DIFF
--- a/src/viewer/ViewportOverlay.css
+++ b/src/viewer/ViewportOverlay.css
@@ -4,6 +4,7 @@
   position: absolute;
   top: 0px;
   left: 0px;
+  z-index: 2;
 }
 
 .ViewportOverlay .overlay-element {


### PR DESCRIPTION
# Changes
- CSS change to move the ViewportOverlay on top of loading div. 