### PR TITLE
fix(labbeling): IE11 fix for labelling getting width too small

### DIFF
--- a/src/select-tree/SelectTree.css
+++ b/src/select-tree/SelectTree.css
@@ -3,7 +3,7 @@
 .select-tree-root {
   display: inline-block;
   text-align: initial;
-  max-width: 320px;
+  width: 320px;
   font-size: 14px;
   line-height: 26px;
 


### PR DESCRIPTION
# Changes
- Setting fixed width to prevent getting it too small on IE11