### PR TITLE
Initial implementation for next case prefetching

### DIFF
--- a/src/case/getNextCase.js
+++ b/src/case/getNextCase.js
@@ -1,8 +1,8 @@
 import getNextCaseForAnnotator from './getNextCaseForAnnotator.js';
 import getCaseImages from './getCaseImages.js';
 
-async function getNextCase(collection, annotatorID) {
-  return getNextCaseForAnnotator(collection, annotatorID).then(getCaseImages);
+async function getNextCase(collection, annotatorID, caseToIgnore) {
+  return getNextCaseForAnnotator(collection, annotatorID, caseToIgnore).then(getCaseImages);
 }
 
 export default getNextCase;

--- a/src/case/getNextCaseForAnnotator.js
+++ b/src/case/getNextCaseForAnnotator.js
@@ -1,10 +1,16 @@
 import { getDB } from '../db.js';
 import getAvailableCases from './getAvailableCases';
 
-//
-// Returns the status the measurement documents for the user for a collection
-// (only return datasets that have been skipped less than skipThreshold)
-//
+/**
+ * Returns the status the measurement documents for the user for a collection
+ * (only return datasets that have been skipped less than skipThreshold)
+ * `caseToIgnore` is used by prefetching in order to prevent the viewer from
+ * loading the same case twice
+ * 
+ * @param {*} collection Cases collection
+ * @param {*} annotatorID ID of the annotator
+ * @param {*} caseToIgnore Case to be ignored
+ */
 async function annotatorCollectionMeasurements(collection, annotatorID, caseToIgnore) {
   // get all available cases for this collection
   const availableCasesPromise = getAvailableCases(collection);

--- a/src/viewer/CornerstoneViewport.js
+++ b/src/viewer/CornerstoneViewport.js
@@ -52,16 +52,28 @@ class CornerstoneViewport extends Component {
 
     const stack = props.viewportData.stack;
 
+    // Get the number of cached images
+    const { cachedImages } = cornerstone.imageCache;
+    let numImagesLoaded = 0;
+    const cachedImageIds = new Set(cachedImages.map(cache => cache.imageId));
+    stack.imageIds.forEach(imageId => {
+      if (cachedImageIds.has(imageId)) {
+        numImagesLoaded++;
+      }
+    });
+
+    const isLoading = numImagesLoaded / stack.imageIds.length < 0.1;
+
     // TODO: Allow viewport as a prop
     this.state = {
       stack,
       imageId: stack.imageIds[0],
       viewportHeight: '100%',
-      isLoading: true,
+      isLoading,
       imageScrollbarValue: 0,
-      numImagesLoaded: 0,
+      numImagesLoaded,
       previousViewport: null,
-      prefetchImages: false
+      prefetchImages: !isLoading
     };
 
     this.displayScrollbar = stack.imageIds.length > 1;
@@ -72,6 +84,7 @@ class CornerstoneViewport extends Component {
     this.onNewImage = this.onNewImage.bind(this);
     this.onWindowResize = this.onWindowResize.bind(this);
     this.onImageLoaded = this.onImageLoaded.bind(this);
+    this.startPrefetching = this.startPrefetching.bind(this);
     this.onStackScroll = this.onStackScroll.bind(this);
     this.startLoadingHandler = this.startLoadingHandler.bind(this);
     this.doneLoadingHandler = this.doneLoadingHandler.bind(this);
@@ -286,6 +299,11 @@ class CornerstoneViewport extends Component {
       this.onImageLoaded
     );
 
+    cornerstone.events.addEventListener(
+      cornerstone.EVENTS.IMAGE_LOAD_FAILED,
+      this.onImageLoaded
+    );
+
     // Load the first image in the stack
     cornerstone.loadAndCacheImage(this.state.imageId).then(image => {
       try {
@@ -480,11 +498,17 @@ class CornerstoneViewport extends Component {
       cornerstone.EVENTS.IMAGE_LOADED,
       this.onImageLoaded
     );
+
+    cornerstone.events.removeEventListener(
+      cornerstone.EVENTS.IMAGE_LOAD_FAILED,
+      this.onImageLoaded
+    );
   }
 
   componentDidUpdate(prevProps) {
     if (prevProps.prefetchedCase !== this.props.prefetchedCase) {
       this.setState({ prefetchImages: true });
+      this.startPrefetching();
     }
 
     // TODO: Add a real object shallow comparison here?
@@ -761,33 +785,40 @@ class CornerstoneViewport extends Component {
     this.hideExtraButtons();
   }
 
-  onImageLoaded(event) {
+  startPrefetching() {
+    if (!this.state.prefetchImages) {
+      return;
+    }
+
+    const { numImagesLoaded } = this.state;
+    const { viewportData } = this.props;
+    const total = viewportData.stack.imageIds.length;
+    if (numImagesLoaded !== total) {
+      return;
+    }
+
+    this.setState({ prefetchImages: false });
+    const { seriesData } = this.props.prefetchedCase;
+    const imageIdsToPrefetch = getImageIdsForSeries(seriesData);
+    const loadNext = () => {
+      if (!imageIdsToPrefetch.length || this.stopPrefetching) {
+        return;
+      }
+
+      const imageId = imageIdsToPrefetch.shift();
+      cornerstone.loadAndCacheImage(imageId).then(loadNext, loadNext);
+    }
+
+    if (this.props.viewportData === viewportData) {
+      loadNext();
+    }
+  }
+
+  onImageLoaded() {
     const { numImagesLoaded } = this.state;
     const newValue = numImagesLoaded + 1;
     this.setState({ numImagesLoaded: newValue });
-
-    const { viewportData } = this.props;
-    const total = viewportData.stack.imageIds.length;
-    if (newValue === total) {
-      if (this.state.prefetchImages) {
-        this.setState({ prefetchImages: false });
-        const { seriesData } = this.props.prefetchedCase;
-        const imageIdsToPrefetch = getImageIdsForSeries(seriesData);
-        const loadNext = () => {
-          if (!imageIdsToPrefetch.length || this.stopPrefetching) {
-            return;
-          }
-
-          const imageId = imageIdsToPrefetch.shift();
-          console.warn('>>>> PREFETCHING IMAGE', imageId);
-          cornerstone.loadAndCacheImage(imageId).then(loadNext, loadNext);
-        }
-
-        if (this.props.viewportData === viewportData) {
-          loadNext();
-        }
-      }
-    }
+    this.startPrefetching();
   }
 
   startLoadingHandler() {

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -149,6 +149,7 @@ class Viewer extends Component {
       props.fetchCaseSuccess(nextCase);
       this.setState({ loading: false });
 
+      // Prefetch next case ignoring the current to prevent loading it twice
       const caseToIgnore = nextCase.data._id;
       getNextCase(this.props.collection, username, caseToIgnore)
         .then(

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -20,7 +20,6 @@ import saveSkipToDatabase from './lib/saveSkipToDatabase.js';
 import saveAchievementsToDatabase from './lib/saveAchievementsToDatabase.js';
 
 import * as cornerstone from 'cornerstone-core';
-import * as cornerstoneWADOImageLoader from 'cornerstone-wado-image-loader';
 import * as cornerstoneTools from 'cornerstone-tools';
 
 import viewerCommands from './lib/viewerCommands.js';
@@ -28,8 +27,13 @@ import LoadingIndicator from '../shared/LoadingIndicator.js';
 
 import './Viewer.css';
 
+<<<<<<< HEAD
 import NotificationContainer from '../notifications/NotificationContainer';
 import NotificationService from '../notifications/NotificationService.js';
+=======
+import NotificationContainer from './notifications/NotificationContainer';
+import getImageIdsForSeries from './lib/getImageIdsForSeries.js';
+>>>>>>> Initial implementation for next case prefetching
 
 const EVENT_KEYDOWN = 'keydown';
 
@@ -133,12 +137,11 @@ class Viewer extends Component {
       toolData: []
     });
 
-    clearOldCornerstoneCacheData();
+    window.viewer = this; // TODO: [prefecth] REMOVE
+    // TODO: [prefecth] Clear the cache of all images except the prefetched ones
+    // clearOldCornerstoneCacheData();
 
-    function nextCaseResolver(nextCase) {
-      console.log('next case', nextCase);
-      props.fetchCaseSuccess(nextCase);
-    }
+    const username = getUsername();
 
     function nextCaseRejector(args) {
       // when there is no valid next case
@@ -147,60 +150,33 @@ class Viewer extends Component {
       props.fetchCaseFailure(args);
     }
 
-    return getNextCase(this.props.collection, getUsername())
+    const nextCaseResolver = (nextCase) => {
+      console.log('next case', nextCase);
+      props.fetchCaseSuccess(nextCase);
+
+      const caseToIgnore = nextCase.data._id;
+      getNextCase(this.props.collection, username, caseToIgnore)
+        .then(
+          prefetchedCase => this.setState({ prefetchedCase }),
+          nextCaseRejector
+        );
+    }
+
+    const { prefetchedCase } = this.state;
+    if (prefetchedCase) {
+      this.setState({ loading: false });
+      nextCaseResolver(prefetchedCase);
+      return Promise.resolve(prefetchedCase);
+    }
+
+    return getNextCase(this.props.collection, username)
       .then(nextCaseResolver, nextCaseRejector)
-      .then(() => {
-        this.setState({
-          loading: false
-        });
-      });
+      .then(() => this.setState({ loading: false }));
   }
 
   getViewportData() {
     const seriesData = this.props.caseData.seriesData;
-    if (!seriesData || !seriesData.length) {
-      return [];
-    }
-
-    let seriesInstances = seriesData[0];
-
-    // Broken in IE?
-    if (typeof seriesInstances === 'string') {
-      seriesInstances = JSON.parse(seriesInstances);
-    }
-
-    let imageIds = seriesInstances.map(instance => {
-      // TODO: use this
-      //const numberOfFrames = instance['00280008'].Value;
-
-      instance['7FE00010'].BulkDataURI = instance[
-        '7FE00010'
-      ].BulkDataURI.replace('http://', 'https://');
-
-      const imageId =
-        'wadors:' + instance['7FE00010'].BulkDataURI + '/frames/1';
-
-      const instanceLowerCaseKeys = {};
-      Object.keys(instance).forEach(key => {
-        instanceLowerCaseKeys[key.toLowerCase()] = instance[key];
-      });
-
-      cornerstoneWADOImageLoader.wadors.metaDataManager.add(
-        imageId,
-        instanceLowerCaseKeys
-      );
-
-      return imageId;
-    });
-
-    imageIds = imageIds.sort((a, b) => {
-      const instanceA = cornerstone.metaData.get('instance', a);
-      const instanceB = cornerstone.metaData.get('instance', b);
-      const instanceNumberA = instanceA['00200013'].Value[0];
-      const instanceNumberB = instanceB['00200013'].Value[0];
-
-      return instanceNumberA - instanceNumberB;
-    });
+    const imageIds = getImageIdsForSeries(seriesData);
 
     return [
       {
@@ -243,6 +219,7 @@ class Viewer extends Component {
               labelDoneCallback={this.labelDoneCallback}
               onNewImage={this.onNewImage}
               setCurrentLesion={this.setCurrentLesion}
+              prefetchedCase={this.state.prefetchedCase}
             />
           ) : (
             <LoadingIndicator />

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -133,9 +133,7 @@ class Viewer extends Component {
       toolData: []
     });
 
-    window.viewer = this; // TODO: [prefecth] REMOVE
-    // TODO: [prefecth] Clear the cache of all images except the prefetched ones
-    // clearOldCornerstoneCacheData();
+    clearOldCornerstoneCacheData(this.state.prefetchedCase);
 
     const username = getUsername();
 
@@ -149,6 +147,7 @@ class Viewer extends Component {
     const nextCaseResolver = (nextCase) => {
       console.log('next case', nextCase);
       props.fetchCaseSuccess(nextCase);
+      this.setState({ loading: false });
 
       const caseToIgnore = nextCase.data._id;
       getNextCase(this.props.collection, username, caseToIgnore)
@@ -160,14 +159,12 @@ class Viewer extends Component {
 
     const { prefetchedCase } = this.state;
     if (prefetchedCase) {
-      this.setState({ loading: false });
       nextCaseResolver(prefetchedCase);
       return Promise.resolve(prefetchedCase);
     }
 
     return getNextCase(this.props.collection, username)
-      .then(nextCaseResolver, nextCaseRejector)
-      .then(() => this.setState({ loading: false }));
+      .then(nextCaseResolver, nextCaseRejector);
   }
 
   getViewportData() {

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -27,13 +27,9 @@ import LoadingIndicator from '../shared/LoadingIndicator.js';
 
 import './Viewer.css';
 
-<<<<<<< HEAD
 import NotificationContainer from '../notifications/NotificationContainer';
 import NotificationService from '../notifications/NotificationService.js';
-=======
-import NotificationContainer from './notifications/NotificationContainer';
 import getImageIdsForSeries from './lib/getImageIdsForSeries.js';
->>>>>>> Initial implementation for next case prefetching
 
 const EVENT_KEYDOWN = 'keydown';
 

--- a/src/viewer/lib/clearOldCornerstoneCacheData.js
+++ b/src/viewer/lib/clearOldCornerstoneCacheData.js
@@ -1,17 +1,32 @@
 import * as cornerstone from 'cornerstone-core';
 import * as cornerstoneWADOImageLoader from 'cornerstone-wado-image-loader';
 import * as cornerstoneTools from 'cornerstone-tools';
+import getImageIdsForSeries from './getImageIdsForSeries';
 
-export default function clearOldCornerstoneCacheData() {
-  // Purge the old image cache, we don't expect to ever load the same case again
-  cornerstone.imageCache.purgeCache();
+export default function clearOldCornerstoneCacheData(prefetchedCase) {
+  if (!prefetchedCase) {
+    // Purge the old image cache, we don't expect to ever load the same case again
+    cornerstone.imageCache.purgeCache();
 
-  // TODO: Check this. Not sure this is necessary, actually, since things should be decached anyway
-  cornerstoneWADOImageLoader.wadouri.dataSetCacheManager.purge();
+    // TODO: Check this. Not sure this is necessary, actually, since things should be decached anyway
+    cornerstoneWADOImageLoader.wadouri.dataSetCacheManager.purge();
 
-  // Clear any old requests in the request pool
-  cornerstoneTools.requestPoolManager.clearRequestStack('interaction');
-  cornerstoneTools.requestPoolManager.clearRequestStack('prefetch');
+    // Clear any old requests in the request pool
+    cornerstoneTools.requestPoolManager.clearRequestStack('interaction');
+    cornerstoneTools.requestPoolManager.clearRequestStack('prefetch');
+  } else {
+    const { imageCache } = cornerstone;
+    const { seriesData } = prefetchedCase;
+    const prefetchedImageIds = new Set(getImageIdsForSeries(seriesData));
+
+    while (
+      (imageCache.cachedImages.length) &&
+      !prefetchedImageIds.has(imageCache.cachedImages[0].imageId)
+    ) {
+      const removedCachedImage = imageCache.cachedImages[0];
+      imageCache.removeImageLoadObject(removedCachedImage.imageId);
+    }
+  }
 
   // Remove all tool data in the tool state manager
   cornerstoneTools.globalImageIdSpecificToolStateManager.restoreToolState({});

--- a/src/viewer/lib/getImageIdsForSeries.js
+++ b/src/viewer/lib/getImageIdsForSeries.js
@@ -1,0 +1,50 @@
+import * as cornerstone from 'cornerstone-core';
+import * as cornerstoneWADOImageLoader from 'cornerstone-wado-image-loader';
+
+export default function getImageIdsForSeries(seriesData) {
+  if (!seriesData || !seriesData.length) {
+    return [];
+  }
+
+  let seriesInstances = seriesData[0];
+
+  // Broken in IE?
+  if (typeof seriesInstances === 'string') {
+    seriesInstances = JSON.parse(seriesInstances);
+  }
+
+  let imageIds = seriesInstances.map(instance => {
+    // TODO: use this
+    //const numberOfFrames = instance['00280008'].Value;
+
+    instance['7FE00010'].BulkDataURI = instance[
+      '7FE00010'
+    ].BulkDataURI.replace('http://', 'https://');
+
+    const imageId =
+      'wadors:' + instance['7FE00010'].BulkDataURI + '/frames/1';
+
+    const instanceLowerCaseKeys = {};
+    Object.keys(instance).forEach(key => {
+      instanceLowerCaseKeys[key.toLowerCase()] = instance[key];
+    });
+
+    cornerstoneWADOImageLoader.wadors.metaDataManager.add(
+      imageId,
+      instanceLowerCaseKeys
+    );
+
+    return imageId;
+  });
+
+  imageIds = imageIds.sort((a, b) => {
+    const instanceA = cornerstone.metaData.get('instance', a);
+    const instanceB = cornerstone.metaData.get('instance', b);
+    const instanceNumberA = instanceA['00200013'].Value[0];
+    const instanceNumberB = instanceB['00200013'].Value[0];
+
+    return instanceNumberA - instanceNumberB;
+  });
+
+  return imageIds;
+}


### PR DESCRIPTION
Prefetching behavior:

- Start prefetching after the current case's last image has been loaded;
- Prefetch image by image sequentially (slower than cornerstone loader which loads 6 images simultaneously);
- If back to dashboard before current stack is loaded stop the prefetching for the next case;
- If completed case before next case prefetching is done, stop the prefetching and let the cornerstone loader do the rest;