### PR TITLE
Using person name on leaderboard page

### DIFF
--- a/src/Leaderboard.js
+++ b/src/Leaderboard.js
@@ -57,12 +57,14 @@ class Leaderboard extends Component {
     return topAnnotatorsLimited.map((item, index) => {
       const rank = startIndex + index + 1;
       const name = item.name;
+      const principalName = item.principalName;
       const score = item.value;
       return (
         <LeaderboardItem
           key={'individual' + rank}
           rank={rank}
           name={name}
+          principalName={principalName}
           score={score}
         />
       );

--- a/src/shared/LeaderboardItem.js
+++ b/src/shared/LeaderboardItem.js
@@ -5,15 +5,16 @@ import './LeaderboardItem.css';
 
 class LeaderboardItem extends Component {
   render() {
+    const { name, principalName, score, rank } = this.props;
+    const nameToDisplay = principalName || name;
+
     return (
       <div className="LeaderboardItem">
-        <div className="rank">{this.props.rank}</div>
-        <div className="name" title={this.props.name}>
-          {this.props.name}
+        <div className="rank">{rank}</div>
+        <div className="name" title={nameToDisplay}>
+          {nameToDisplay}
         </div>
-        <div className="score">
-          {this.props.score && this.props.score.toLocaleString()}
-        </div>
+        <div className="score">{score && score.toLocaleString()}</div>
       </div>
     );
   }
@@ -22,7 +23,8 @@ class LeaderboardItem extends Component {
 LeaderboardItem.propTypes = {
   score: PropTypes.number,
   rank: PropTypes.number,
-  name: PropTypes.string
+  name: PropTypes.string,
+  principalName: PropTypes.string
 };
 
 export default LeaderboardItem;

--- a/src/shared/getTopAnnotators.js
+++ b/src/shared/getTopAnnotators.js
@@ -24,7 +24,8 @@ async function getTopAnnotators(limit = 10) {
   measByAnno = measByAnno.filter(a => a.key !== null);
 
   // TODO: Sort in the View
-  measByAnno.sort((a, b) => b.value.username - a.value.username);
+  // TODO: check it might not be really necessary (could use query param instead)
+  measByAnno.sort((a, b) => b.value.name - a.value.name);
 
   const annotators = measByAnno.map(instance => {
     const { key, value } = instance;

--- a/src/shared/getTopAnnotators.js
+++ b/src/shared/getTopAnnotators.js
@@ -11,7 +11,7 @@ async function getTopAnnotators(limit = 10) {
   // of annotators we will have in the near future this is not required
   // (remember, we are fetching hundreds of CT images all the time, so
   // a few dozen lines of json is nothing!)
-  const result = await measurementsDB.query('by/annotators', {
+  const result = await measurementsDB.query('by/annotatorsInfo', {
     reduce: true,
     group: true,
     level: 'exact'
@@ -24,12 +24,14 @@ async function getTopAnnotators(limit = 10) {
   measByAnno = measByAnno.filter(a => a.key !== null);
 
   // TODO: Sort in the View
-  measByAnno.sort((a, b) => b.value - a.value);
+  measByAnno.sort((a, b) => b.value.username - a.value.username);
 
-  const annotators = measByAnno.map(r => {
+  const annotators = measByAnno.map(instance => {
+    const { key, value } = instance;
     return {
-      name: r.key,
-      value: r.value
+      name: key,
+      principalName: value.principalName,
+      value: value.count
     };
   });
 

--- a/src/shared/getTopAnnotators.js
+++ b/src/shared/getTopAnnotators.js
@@ -24,8 +24,7 @@ async function getTopAnnotators(limit = 10) {
   measByAnno = measByAnno.filter(a => a.key !== null);
 
   // TODO: Sort in the View
-  // TODO: check it might not be really necessary (could use query param instead)
-  measByAnno.sort((a, b) => b.value.name - a.value.name);
+  measByAnno = measByAnno.sort((a, b) => b.value.count - a.value.count);
 
   const annotators = measByAnno.map(instance => {
     const { key, value } = instance;

--- a/src/viewer/lib/saveMeasurementToDatabase.js
+++ b/src/viewer/lib/saveMeasurementToDatabase.js
@@ -1,6 +1,6 @@
 // Retrieve the tool state manager for this element
 import guid from './guid.js';
-import getUsername from './getUsername.js';
+import getProfile from './getProfile.js';
 import dataURItoBlob from './dataUriToBlob.js';
 import { getDB } from '../../db.js';
 import * as cornerstone from 'cornerstone-core';
@@ -96,13 +96,17 @@ function saveAttachment(measurement, response) {
 
 async function saveMeasurementToDatabase(caseData, measurements, feedback) {
   const measurementsDB = getDB('measurements');
-  const annotator = await getUsername();
+  const {
+    name: annotatorPrincipalName = '',
+    username: annotator = ''
+  } = await getProfile();
 
   const promises = measurements.map(async measurement => {
     const doc = {
       _id: guid(),
       measurement,
       annotator,
+      annotatorPrincipalName,
       skip: false,
       feedback,
       caseData: caseData.data,

--- a/src/viewer/lib/saveSkipToDatabase.js
+++ b/src/viewer/lib/saveSkipToDatabase.js
@@ -1,15 +1,19 @@
 import guid from './guid.js';
-import getUsername from './getUsername.js';
+import getProfile from './getProfile.js';
 import { getDB } from '../../db.js';
 
 async function saveSkipToDatabase(caseData, feedback) {
   const measurementsDB = getDB('measurements');
-  const annotator = getUsername();
+  const {
+    name: annotatorPrincipalName = '',
+    username: annotator = ''
+  } = await getProfile();
 
   const doc = {
     _id: guid(),
     skip: true,
     annotator,
+    annotatorPrincipalName,
     feedback,
     caseData: caseData.data,
     date: Math.floor(Date.now() / 1000),


### PR DESCRIPTION
### Includes
- New viewer into couchdb doc to return personName, userName, counter named as `annotatorsInfo` (already in place)
- Update LeaderBoardItem to display personName or userName.
- Kept compatibility for other leaderBoard usage.
- From now on couchdb/ Measurements doc will be updated with new field for personName. In case we that info right away we will need to re-hydrated measurements doc for given db

### Screenshot
PS: Displaying a lot of Top Annotators just for testing purpose (i.e this change is not present on PR)
![Crowds-Cure-Cancer-_2_](https://user-images.githubusercontent.com/39910206/69454786-c22f3680-0d45-11ea-9228-73a3b6244b42.gif)
