### PR TITLE
White viewer on safari browser

### DIFF
--- a/src/AppPageAnimations.css
+++ b/src/AppPageAnimations.css
@@ -8,17 +8,14 @@
 @value defaultEnterAnimation: 2s defaultTiming;
 
 .route-container {
-  width: inherit;
-  height: inherit;
-  position: relative;
+  width: 100%;
+  height: 100%;
 }
 
 .route-section {
   width: 100%;
   height: 100%;
-  left: 0;
   position: absolute;
-  top: 0;
   overflow-y: hidden;
 }
 


### PR DESCRIPTION
### Includes
- safari doesn t fully support position relative for non content. So, thats why it works for resizing page (i.e viewer re-render). So we can live without it on code implementation