### PR TITLE
User to click once to open/close label tree (by Rodolfo)

### DIFF
--- a/src/viewer/CornerstoneViewport.js
+++ b/src/viewer/CornerstoneViewport.js
@@ -216,11 +216,16 @@ class CornerstoneViewport extends Component {
   }
 
   updateLabelHandler(originElement) {
-    const { currentLesion, toolData } = this.props;
+    const { currentLesion, toolData, displayLabelSelectTree } = this.props;
     let index = currentLesion >= 0 ? currentLesion - 1 : toolData.length - 1;
     const currentToolData = toolData[index];
 
     if (!currentToolData) {
+      return;
+    }
+
+    if (!displayLabelSelectTree) {
+      this.setState({ bidirectionalAddLabelShow: false });
       return;
     }
 
@@ -564,13 +569,14 @@ class CornerstoneViewport extends Component {
       });
     }
 
-    const { labelSelectTreeOrigin } = this.props;
-    const showStateChanged =
-      labelSelectTreeOrigin &&
-      labelSelectTreeOrigin !== prevProps.labelSelectTreeOrigin;
+    const { labelSelectTreeOrigin, displayLabelSelectTree } = this.props;
     const currentLesionChanged =
       this.props.currentLesion !== prevProps.currentLesion;
-    if (showStateChanged) {
+
+    const currentDisplayLabel =
+      displayLabelSelectTree !== prevProps.displayLabelSelectTree;
+
+    if (currentLesionChanged || currentDisplayLabel) {
       this.updateLabelHandler(labelSelectTreeOrigin);
     }
 
@@ -965,6 +971,7 @@ CornerstoneViewport.propTypes = {
   activeTool: PropTypes.string.isRequired,
   viewportData: PropTypes.object.isRequired,
   labelSelectTreeOrigin: PropTypes.object,
+  displayLabelSelectTree: PropTypes.boolean,
   labelDoneCallback: PropTypes.func,
   currentLesionFocused: PropTypes.bool,
   magnificationActive: PropTypes.bool,

--- a/src/viewer/Viewer.js
+++ b/src/viewer/Viewer.js
@@ -50,6 +50,7 @@ class Viewer extends Component {
       loading: true,
       magnificationActive: false,
       labelSelectTreeOrigin: null,
+      displayLabelSelectTree: false,
       currentLesionFocused: false,
       feedback: [],
       hasMeasurements: false,
@@ -110,6 +111,15 @@ class Viewer extends Component {
 
     if (this.state.labelSelectTreeOrigin && !this.state.hasMeasurements) {
       this.setState({ labelSelectTreeOrigin: null });
+    }
+
+    // Force closing labelSelectTree on user interactions not related to label
+    if (
+      prevState.displayLabelSelectTree === this.state.displayLabelSelectTree &&
+      this.state.displayLabelSelectTree &&
+      (this.state.labelSelectTreeOrigin === null || this.state.hasMeasurements)
+    ) {
+      this.setState({ displayLabelSelectTree: false });
     }
 
     NotificationService.setCaseMeasurements(this.state.toolData.length);
@@ -210,6 +220,7 @@ class Viewer extends Component {
               viewportData={item}
               activeTool={activeTool}
               labelSelectTreeOrigin={this.state.labelSelectTreeOrigin}
+              displayLabelSelectTree={this.state.displayLabelSelectTree}
               labelDoneCallback={this.labelDoneCallback}
               onNewImage={this.onNewImage}
               setCurrentLesion={this.setCurrentLesion}
@@ -478,16 +489,26 @@ class Viewer extends Component {
   }
 
   toggleLabelSelectTree(event) {
-    const { hasMeasurements, labelSelectTreeOrigin } = this.state;
+    const {
+      hasMeasurements,
+      displayLabelSelectTree: _displayLabelSelectTree
+    } = this.state;
     if (hasMeasurements) {
       this.focusCurrentLesion();
-      const newValue = labelSelectTreeOrigin ? null : event.target;
-      this.setState({ labelSelectTreeOrigin: newValue });
+      const newValue = event.target;
+      const displayLabelSelectTree = !_displayLabelSelectTree;
+      this.setState({
+        labelSelectTreeOrigin: newValue,
+        displayLabelSelectTree
+      });
     }
   }
 
   labelDoneCallback() {
-    this.setState({ labelSelectTreeOrigin: null });
+    this.setState({
+      labelSelectTreeOrigin: null,
+      displayLabelSelectTree: false
+    });
   }
 }
 


### PR DESCRIPTION
Credits to @ladeirarodolfo;
Fixed issue with user needing to click twice to open/close labelling panel;