### PR TITLE
Displaying rank badge notifications as soon as measurement is created

### DIFF
--- a/src/caseNotifications.js
+++ b/src/caseNotifications.js
@@ -3,18 +3,15 @@ import notificationOnFire from './images/general/notification-on-fire.svg';
 const caseNotifications = {
   noMeasurements: {
     min: 0,
-    alertDiff: 0,
     alertMessage: 'Measure lesions to get points'
   },
   firstMeasurement: {
     min: 1,
-    alertDiff: 0,
     alertMessage: 'Label the lesion to add more value to the data'
   },
   NUM_CASES_ROOKIE: {
     img: notificationOnFire,
     min: 35,
-    alertDiff: 0,
     alertTitle: 'You’re on fire!',
     alertMessage: 'Your contribution is greatly appreciated'
   }

--- a/src/notifications/NotificationContainer.css
+++ b/src/notifications/NotificationContainer.css
@@ -3,8 +3,8 @@
 
 .NotificationContainer {
   position: fixed;
-  right: 366px;
-  top: 38px;
+  right: 400px;
+  top: 45px;
   width: 330px;
   z-index: 150;
 }

--- a/src/notifications/NotificationService.js
+++ b/src/notifications/NotificationService.js
@@ -48,6 +48,9 @@ class NotificationService {
   setCaseMeasurements(caseMeasurements) {
     this.caseMeasurements = caseMeasurements;
 
+    const rankBadgeAlert = this.getRankBadgeAlert();
+    const alerts = rankBadgeAlert ? [rankBadgeAlert] : [];
+    this.processAlerts(alerts);
     this.processCaseAlerts();
   }
 
@@ -56,7 +59,7 @@ class NotificationService {
     this.achievementStatus = achievementStatus;
     this.achievements = Array.from(achievements);
 
-    this.processAlerts();
+    this.processAlerts(this.getAchievementAlerts());
     this.processEarnedBadges();
   }
 
@@ -81,14 +84,7 @@ class NotificationService {
     });
   }
 
-  processAlerts() {
-    const rankBadgeAlert = this.getRankBadgeAlert();
-    const achievementAlerts = this.getAchievementAlerts();
-    const alerts = Array.from(achievementAlerts);
-    if (rankBadgeAlert) {
-      alerts.unshift(rankBadgeAlert);
-    }
-
+  processAlerts(alerts) {
     let wait = 0;
     alerts.forEach(details => {
       if (this.alerted.has(details)) {
@@ -96,8 +92,10 @@ class NotificationService {
       }
 
       const { img, min, alertTitle, alertMessage } = details;
-      let current = this.totalMeasurements;
-      if (!details.type) {
+      let current;
+      if (details.type) {
+        current = this.totalMeasurements + this.caseMeasurements;
+      } else {
         current = this.achievementStatus[details.statusKey];
       }
 
@@ -163,7 +161,7 @@ class NotificationService {
       }
 
       const { min, alertDiff } = details;
-      const current = this.totalMeasurements;
+      const current = this.totalMeasurements + this.caseMeasurements;
       if (current >= min - alertDiff && current < min) {
         badgeToAlert = details;
         return false;


### PR DESCRIPTION
Started displaying rank badge notifications as soon as measurements are created instead of displaying only after completing a case;
Achievement badges notifications are still being displayed only after completing a case because we need to get the achievements status calculated from DB view.