### PR TITLE
Prevent component rerender on every imagererender.

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "react-transition-group": "^2.5.0",
     "redux": "^4.0.1",
     "rollbar": "^2.5.0",
+    "underscore": "^1.9.1",
     "whatwg-fetch": "^3.0.0"
   },
   "husky": {

--- a/src/viewer/ViewportOverlay.js
+++ b/src/viewer/ViewportOverlay.js
@@ -6,19 +6,22 @@ import PropTypes from 'prop-types';
 
 class ViewportOverlay extends Component {
   render() {
-    // TODO: Round the value to 2 decimals
-    const scale = Math.round(this.props.viewport.scale * 100) / 100;
-    const imageId = this.props.imageId;
+    const {
+      roundedViewportScale,
+      imageId,
+      viewportVoi,
+      stack,
+      numImagesLoaded
+    } = this.props;
 
     const patientId = cornerstone.metaData.get('00100020', imageId);
     const studyDate = cornerstone.metaData.get('00080020', imageId);
     const collection = cornerstone.metaData.get('00131010', imageId);
     const studyDescription = cornerstone.metaData.get('00081030', imageId);
 
-    const windowWidth = Math.round(this.props.viewport.voi.windowWidth);
-    const windowCenter = Math.round(this.props.viewport.voi.windowCenter);
-    const imagesLeft =
-      this.props.stack.imageIds.length - this.props.numImagesLoaded;
+    const windowWidth = Math.round(viewportVoi.windowWidth);
+    const windowCenter = Math.round(viewportVoi.windowCenter);
+    const imagesLeft = stack.imageIds.length - numImagesLoaded;
 
     return (
       <div className="ViewportOverlay">
@@ -31,14 +34,15 @@ class ViewportOverlay extends Component {
             {imagesLeft > 0 ? `${imagesLeft} images remaining...` : ''}
           </span>
         </div>
-        <div className="bottom-left overlay-element">Zoom: {scale}</div>
+        <div className="bottom-left overlay-element">
+          Zoom: {roundedViewportScale}
+        </div>
         <div className="bottom-right overlay-element">
           <span>
             WW/WC: {windowWidth} / {windowCenter}
           </span>
           <span>
-            Image: {this.props.stack.currentImageIdIndex + 1} /{' '}
-            {this.props.stack.imageIds.length}
+            Image: {stack.currentImageIdIndex + 1} / {stack.imageIds.length}
           </span>
         </div>
       </div>
@@ -47,7 +51,8 @@ class ViewportOverlay extends Component {
 }
 
 ViewportOverlay.propTypes = {
-  viewport: PropTypes.object.isRequired,
+  viewportVoi: PropTypes.object.isRequired,
+  roundedViewportScale: PropTypes.number.isRequired,
   imageId: PropTypes.string.isRequired,
   stack: PropTypes.object.isRequired
 };


### PR DESCRIPTION
### Includes
Bug description:
- After adding a measurement if user move mouse (not hovering measurement), this current measurement keeps blinking from yellow to green color
Bug cause:
- cornerstoneViewport component re-renders every time image is re-rendered.
Reduced this operation to re-render cornerstoneViewport component (base on image re-rendered) only if props for ViewerOverlay has changed.


NOT COVERED YET
- Need to cover imageLoaded event.. which is causing the same issue as mentioned above. 
