### PR TITLE
Moving notification container down on mobile devices

### DIFF
--- a/src/notifications/NotificationContainer.css
+++ b/src/notifications/NotificationContainer.css
@@ -24,9 +24,9 @@
 
 @media (max-width: screen-min) {
   .NotificationContainer {
-    right: 5px;
-    top: 4px;
-    width: calc(100% - 10px);
+    right: 8px;
+    top: 150px;
+    width: calc(100% - 16px);
   }
 
   .NotificationContainer .NotificationToast {


### PR DESCRIPTION
Moved notification container down on mobile devices, preventing it from being displayed in front of header, tools or measurement controls.